### PR TITLE
Configure TPM location with TCTI instead of device path

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,14 @@ Copy the CSR from the device with `cat` on the device or `scp` on the host and
 sign the CSR with the root or intermediate CA. Copy the signed certificate back
 to the device. For some connections, concatenating the entire certificate bundle
 into a file may be necessary.
+
+### Setting the TCTI
+
+By default, the TPM Command Transmission Interface (TCTI) is set to
+`device:/dev/tpmrm0` since this is the default path for a hardware TPM.
+This can be changed by setting the `:tcti` application property in the
+project's mix config.
+
+```ex
+config :tpm, :tcti, "device:/dev/tpmrm0"
+```

--- a/lib/tpm.ex
+++ b/lib/tpm.ex
@@ -10,7 +10,7 @@ defmodule TPM do
     | {:error, :unsupported_scheme, message :: String.t}
     | {:error, return_code :: non_neg_integer, message :: String.t}
 
-  @tpm_device Application.compile_env(:tpm, :device_path, "/dev/tpmrm0")
+  @tpm_tcti Application.compile_env(:tpm, :tcti, "device:/dev/tpmrm0")
 
   @doc """
   Clear the TPM.
@@ -23,7 +23,7 @@ defmodule TPM do
   def clear(opts)
 
   def clear(confirm: true) do
-    case cmd("tpm2_clear", ["-T", "device:#{@tpm_device}"]) do
+    case cmd("tpm2_clear", ["-T", @tpm_tcti]) do
       {:ok, _} -> :ok
       error    -> error
     end
@@ -38,7 +38,7 @@ defmodule TPM do
   """
   @spec getcap(capability :: :handles_nv_index) :: {:ok, [String.t]} | tpm2_error
   def getcap(_capability = :handles_nv_index) do
-    case cmd("tpm2_getcap", ["-T", "device:#{@tpm_device}", "handles-nv-index"]) do
+    case cmd("tpm2_getcap", ["-T", @tpm_tcti, "handles-nv-index"]) do
       {:ok, stdout} ->
         addresses =
           stdout
@@ -75,7 +75,7 @@ defmodule TPM do
           acc
       end)
 
-    case cmd("tpm2_nvdefine", ["-T", "device:#{@tpm_device}"] ++ args) do
+    case cmd("tpm2_nvdefine", ["-T", @tpm_tcti] ++ args) do
       {:ok, stdout} ->
         # stdout format:
         # nv-index: 0x1000001
@@ -116,7 +116,7 @@ defmodule TPM do
 
     case cmd(
       "tpm2_nvread",
-      ["-T", "device:#{@tpm_device}"] ++ args ++ [address],
+      ["-T", @tpm_tcti] ++ args ++ [address],
       stderr_to_stdout: !return_contents?
     ) do
       {:ok, _stdout} when not return_contents? ->
@@ -136,7 +136,7 @@ defmodule TPM do
   """
   @spec nvwrite(address :: String.t, path :: String.t) :: :ok | tpm2_error
   def nvwrite(address, path) do
-    case cmd("tpm2_nvwrite", ["-i", path, "-T", "device:#{@tpm_device}", address]) do
+    case cmd("tpm2_nvwrite", ["-i", path, "-T", @tpm_tcti, address]) do
       {:ok, _} -> :ok
       error    -> error
     end

--- a/lib/tpm/tss.ex
+++ b/lib/tpm/tss.ex
@@ -3,7 +3,7 @@ defmodule TPM.TSS do
   Elixir wrapper for [tpm2tss](https://github.com/tpm2-software/tpm2-tss).
   """
 
-  @tpm_device Application.compile_env(:tpm, :device_path, "/dev/tpmrm0")
+  @tpm_tcti Application.compile_env(:tpm, :tcti, "device:/dev/tpmrm0")
 
   @doc """
   Generate TPM keys for tpm2-tss-engine.
@@ -14,7 +14,7 @@ defmodule TPM.TSS do
   @spec genkey(output_path :: String.t) ::
     :ok | {:error, return_code :: non_neg_integer, message :: String.t}
   def genkey(output_path) do
-    case cmd("tpm2tss-genkey", ["-a", "rsa", "-t", "device:#{@tpm_device}", output_path]) do
+    case cmd("tpm2tss-genkey", ["-a", "rsa", "-t", @tpm_tcti, output_path]) do
       {:ok, _} -> :ok
       error    -> error
     end

--- a/spec/tpm/crypto_spec.exs
+++ b/spec/tpm/crypto_spec.exs
@@ -8,7 +8,6 @@ defmodule TPM.Crypto.Spec do
   let :private_key_path, do: "/tmp/tpm_ex/key"
 
   context "engine:" do
-
     it "returns an OTP crypto engine for tpm2tss" do
       allow :crypto |> to(accept :ensure_engine_loaded, fn name, path ->
         name |> should(eq "tpm2tss")


### PR DESCRIPTION
TPM location is now configurable by specifying its TCTI, like this:

```ex
config :tpm, :tcti, "device:/dev/tpmrm0"
```